### PR TITLE
fix file not found error when deploy contract twice

### DIFF
--- a/routes/routes.js
+++ b/routes/routes.js
@@ -52,25 +52,29 @@ var appRouter = function (app) {
 
 
     app.post("/deploy", async function (req, res) {
-        let tokenId = req.body.tokenId; 
-        await buildUtil.makeBuildDir(tokenId);
-        await buildUtil.prepContractDir(tokenId);
-        await buildUtil.buildCrowdsaleContract(tokenId);
+        let tokenId = req.body.tokenId;
+        try {
+            await buildUtil.makeBuildDir(tokenId);
+            await buildUtil.prepContractDir(tokenId);
+            await buildUtil.buildCrowdsaleContract(tokenId);
 
-        let tokenObject = await tokenService.getTokenByTokenId(tokenId);
-        let tokenJSON = tokenObject.toJSON();
+            let tokenObject = await tokenService.getTokenByTokenId(tokenId);
+            let tokenJSON = tokenObject.toJSON();
 
-        let crowdsaleObject = await crowdsaleService.getCrowdsaleByTokenId(tokenId);
-        let crowdsaleJSON = crowdsaleObject.toJSON();
+            let crowdsaleObject = await crowdsaleService.getCrowdsaleByTokenId(tokenId);
+            let crowdsaleJSON = crowdsaleObject.toJSON();
 
-        await buildUtil.buildTokenContract(tokenId, tokenJSON.name, tokenJSON.symbol);
+            await buildUtil.buildTokenContract(tokenId, tokenJSON.name, tokenJSON.symbol);
 
-        await buildUtil.prepMergeDir(tokenId);
-        await buildUtil.mergeCrowdsaleContract(tokenId);
-        let contractAddress = await buildUtil.deployCrowdsaleContract(tokenId, crowdsaleJSON);
+            await buildUtil.prepMergeDir(tokenId);
+            await buildUtil.mergeCrowdsaleContract(tokenId);
+            let contractAddress = await buildUtil.deployCrowdsaleContract(tokenId, crowdsaleJSON);
 
-        console.log('deployed address:', contractAddress);
-        res.send(contractAddress);
+            console.log('deployed address:', contractAddress);
+            res.send(contractAddress);
+        } catch (e) {
+            res.status(500).send('deployment failed');
+        }
     });
 }
 module.exports = appRouter;

--- a/utils/build.js
+++ b/utils/build.js
@@ -89,15 +89,18 @@ exports.mergeCrowdsaleContract = async function (tokenId) {
     const MERGE_DIR_PATH = path.join(PWD, '/../.build/', tokenId, '/', MERGE_DIR_NAME);
 
     const shell = require('shelljs');
-    shell.cd(ORACLES_COMBINE_DIR_PATH);
 
     let CROWDSALE_FILE_PATH = path.join(BUILD_DIR_PATH, '/', tokenId, '/', CONTRACT_DIR_NAME,'/', CROWDSALE_FILE_NAME);
     console.log(CROWDSALE_FILE_PATH);
-    if (shell.exec('npm start ' + CROWDSALE_FILE_PATH).code !== 0) {
-        shell.echo('Error: merge file failed');
-        shell.exit(1);
+    if (shell.exec('npm start --prefix '+ ORACLES_COMBINE_DIR_PATH + ' ' + CROWDSALE_FILE_PATH).code !== 0) {
+        console.log('oracle compbine npm install failed');
+        throw new Error('Error: merge file failed');
     } else {
-        shell.mv(ORACLES_COMBINE_OUT_DIR_PATH + '/CrowdSale_flat.sol',  path.join(MERGE_DIR_PATH, '/', CROWDSALE_FILE_NAME));
+        let mvRes = shell.mv(ORACLES_COMBINE_OUT_DIR_PATH + '/CrowdSale_flat.sol',  path.join(MERGE_DIR_PATH, '/', CROWDSALE_FILE_NAME));
+        if (mvRes.code !== 0) {
+            console.log('failed to move flat sol file');
+            throw new Error('Error: merge file failed');
+        }
     }
 
 };


### PR DESCRIPTION
@judezhu 
use npm --prefix arg to specify package path when combine file with orable.
improved error handling to prevent server crash